### PR TITLE
 feat : 롤리페이퍼 정보 반환

### DIFF
--- a/backend/rollpaper/models.py
+++ b/backend/rollpaper/models.py
@@ -49,13 +49,14 @@ class Memo(models.Model):
 
 class Image(models.Model):
     paper = models.ForeignKey(Paper,on_delete=models.CASCADE) #paper_id로 저장
-    image_url = models.FileField(max_length=200) #블로그 참고로 imageFiled -> FileField로 수정
+    image_url = models.URLField(max_length=200) #블로그 참고로 imageFiled -> FileField로 수정
+    # JSON으로 만들 때 에러나서 다시 FileField에서 URLField로 수정
     xcoor = models.IntegerField() 
     ycoor = models.IntegerField() 
     rotate = models.IntegerField() 
-    password = models.CharField(max_length=20)
-    create_at = models.DateTimeField(auto_now_add=True)
-    update_at = models.DateTimeField(auto_now=True)
+    password = models.CharField(max_length=20) 
+    create_at = models.DateTimeField(auto_now_add=True) 
+    update_at = models.DateTimeField(auto_now=True) 
     is_deleted = models.IntegerField(default=1) 
 
 class DefaultSticker(models.Model):

--- a/backend/rollpaper/serializers.py
+++ b/backend/rollpaper/serializers.py
@@ -1,0 +1,45 @@
+import json
+from .models import*
+
+#짝퉁 시리어라이즈 : 딕셔너리로 만들어 줌
+def memo_serializer(memo_queryset):
+    dic = {}
+    dic['content'] = memo_queryset.content
+    dic['nickname'] = memo_queryset.nickname
+    dic['password'] = memo_queryset.password
+    dic['xcoor'] = memo_queryset.xcoor
+    dic['ycoor'] = memo_queryset.ycoor
+    dic['rotate'] = memo_queryset.rotate
+    font_id = memo_queryset.font_id #memo에 있는 font_id를 가져옴
+    #그 아이디를 기준으로 폰트 컬럼(행)을 찾아서 font_type( ex)"안성탕면체")을 가져옴
+    font = Font.objects.get(pk=font_id).font_type 
+    dic["font"] = font
+    
+    #json이랑 dictionary랑 뭐가 다른지는 모르겠는데 JSON으로 만들어주는 느낌
+    # json_dic = json.dumps(dic) 
+    return dic #json_dic
+
+def image_serializer(image_queryset):
+    dic = {}
+    dic['password'] = image_queryset.password
+    dic['xcoor'] = image_queryset.xcoor
+    dic['ycppr'] = image_queryset.ycoor
+    dic['rotate'] = image_queryset.rotate
+    #이미지 url을 가져와야해 폰트와 다르게 이미지 테이블에 url이 있어
+    dic['image_url'] = image_queryset.image_url
+
+    return dic
+
+def sticker_serializer(sticker_queryset):
+    dic = {}
+    dic['password'] = sticker_queryset.password
+    dic['xcoor'] = sticker_queryset.xcoor
+    dic['ycoor'] = sticker_queryset.ycoor
+    dic['rotate'] = sticker_queryset.rotate
+    #스티커가 가지고 있는 스티커 저장소의 기본키를 가져온다
+    sticker_id = sticker_queryset.default_sticker_id
+    #그 기본키로 탐색해서 url을 가져온다
+    sticker_url = DefaultSticker.objects.get(pk=sticker_id).sticker_url
+    dic['sticker_url'] = sticker_url
+
+    return dic

--- a/backend/rollpaper/urls.py
+++ b/backend/rollpaper/urls.py
@@ -10,5 +10,6 @@ urlpatterns = [
     path('papers/<int:paper_id>/photos',views.photo),#사진 추가
     path('papers/<int:paper_id>/memos',views.memo), #메모 생성
     path('papers/<int:memo_id>',views.memo_delete), #메모 삭제
-    path('papers/<int:paper_id>/stickers',views.stickers) #스티커를 추가
+    path('papers/<int:paper_id>/stickers',views.stickers), #스티커를 추가
+    path('papers/<int:user_id>/<paper_id>',views.get_paper) #paper의 memo,image,sticker의 정보를 가져옵니다
 ]

--- a/backend/rollpaper/views.py
+++ b/backend/rollpaper/views.py
@@ -6,6 +6,7 @@ import boto3
 from botocore.client import Config
 from backend.settings import AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
 from backend.settings import AWS_BUCKET_REGION, AWS_STORAGE_BUCKET_NAME
+from .serializers import *
 # Create your views here.
 @api_view(['POST']) 
 def login(request):
@@ -147,3 +148,25 @@ def stickers(request,paper_id):
     return JsonResponse({"message": "sticker added"}, status=201)
     
     #실패하는 케이스는 생각을 못했고 사진을 가리면 안되는 느낌으로 추가구현하면 좋을 거 같습니다
+
+@api_view(['GET'])
+def get_paper(request,user_id,paper_id): #user_id는 쓰나?
+    #TODO memo 먼저 하자
+    dict={"memo":[],"image":[],"sticker":[]}
+    for memo in Memo.objects.filter(paper=paper_id): #아마 리스트 형식으로 쿼리셋을 반환할 거에요
+        json_memo_part = memo_serializer(memo) #memo에서 필요한 정보를 JSON으로 바꿔줍니다
+        #근데 JSON으로 바꾸려고 하니까 딕셔너리에 추가할 때 오류가 발생해서 그냥 dic으로 반환
+        #memo의 value값에 방금 만든 json을 추가하여 수정해 줍니다
+        dict["memo"].append(json_memo_part)
+    
+    for image in Image.objects.filter(paper=paper_id):
+        json_image_part = image_serializer(image) #딕셔너리 만들기
+        dict["image"].append(json_image_part) #원본에 추가
+    
+    for sticker in Sticker.objects.filter(paper_id=paper_id):
+        json_sticker_part = sticker_serializer(sticker)
+        dict["sticker"].append(json_sticker_part)
+    
+    # json_dict = json.dumps(dict, ensure_ascii=False)
+     
+    return JsonResponse(dict, safe=False )


### PR DESCRIPTION
## 추가/수정한 기능 설명
image 테이를의 image_url의 Field를 FileField에서 URLField로 수정했습니다.
paper_id를 기준으로 메모, 이미지, 스티커 중에서 요청한 paper_id를 가지고 있는 데이터들을 모두 불러와 반환해 주는 기능입니다
<br>


## check list
- [x] issue number를 브랜치 앞에 추가 하였는가?
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
- [x] 추가/수정사항을 설명하였는가?