### PR TITLE
Fix/#31 memo api 수정

### DIFF
--- a/backend/rollpaper/models.py
+++ b/backend/rollpaper/models.py
@@ -34,12 +34,13 @@ class Color(models.Model):
 class Memo(models.Model):
     paper = models.ForeignKey(Paper,on_delete=models.CASCADE) #paper_id로 저장
     font = models.ForeignKey(Font,on_delete=models.CASCADE) #폰트랑 색깔이 삭제되면 메모도 사라져
-    color = models.ForeignKey(Color,on_delete=models.CASCADE) #color_id로 저장
+    color = models.ForeignKey(to = Color, related_name='+',on_delete=models.CASCADE,verbose_name='메모지색',default='') #color_id로 저장
+    font_color = models.ForeignKey(to = Color,related_name='+',on_delete=models.CASCADE,verbose_name='글씨색',default='')
     content = models.CharField(max_length=200) 
     nickname = models.CharField(max_length=20) 
-    xcoor = models.IntegerField() 
-    ycoor = models.IntegerField() 
-    rotate = models.IntegerField() 
+    xcoor = models.IntegerField(null=True) 
+    ycoor = models.IntegerField(null=True) 
+    #rotate = models.IntegerField() 
     password = models.CharField(max_length=20) 
     create_at = models.DateTimeField(auto_now_add=True) 
     update_at = models.DateTimeField(auto_now=True) 

--- a/backend/rollpaper/models.py
+++ b/backend/rollpaper/models.py
@@ -34,8 +34,8 @@ class Color(models.Model):
 class Memo(models.Model):
     paper = models.ForeignKey(Paper,on_delete=models.CASCADE) #paper_id로 저장
     font = models.ForeignKey(Font,on_delete=models.CASCADE) #폰트랑 색깔이 삭제되면 메모도 사라져
-    color = models.ForeignKey(to = Color, related_name='+',on_delete=models.CASCADE,verbose_name='메모지색',default='') #color_id로 저장
-    font_color = models.ForeignKey(to = Color,related_name='+',on_delete=models.CASCADE,verbose_name='글씨색',default='')
+    color = models.ForeignKey(to = Color, related_name='color',on_delete=models.CASCADE,verbose_name='메모지색',default='') #color_id로 저장
+    font_color = models.ForeignKey(to = Color,related_name='font_color',on_delete=models.CASCADE,verbose_name='글씨색',default='')
     content = models.CharField(max_length=200) 
     nickname = models.CharField(max_length=20) 
     xcoor = models.IntegerField(null=True) 

--- a/backend/rollpaper/serializers.py
+++ b/backend/rollpaper/serializers.py
@@ -27,7 +27,6 @@ def memo_serializer(memo_queryset):
     dic['password'] = memo_queryset.password
     dic['xcoor'] = memo_queryset.xcoor
     dic['ycoor'] = memo_queryset.ycoor
-    dic['rotate'] = memo_queryset.rotate
     font_id = memo_queryset.font_id #memo에 있는 font_id를 가져옴
     #그 아이디를 기준으로 폰트 컬럼(행)을 찾아서 font_type( ex)"안성탕면체")을 가져옴
     font = Font.objects.get(pk=font_id).font_type 
@@ -86,12 +85,17 @@ class PhotoSerializer(serializers.ModelSerializer):
 class MemoSerializer(serializers.ModelSerializer):
     class Meta: #paper_id는 views.py에서 입력받으므로 serializer에서는 넣지 않음
         model = Memo
-        fields = ('font','color','content','nickname','xcoor','ycoor','rotate','password')
+        fields = ('font','color','content','nickname', 'password')
+
+class MemoXySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Memo
+        fields = ('xcoor','ycoor')
 
 class MemoDeleteSerializer(serializers.ModelSerializer):
     class Meta:
         model = Memo
-        fields = ('id','is_deleted')
+        fields = ('id','password') # is_deleted는 views.py에서 자동 변환하므로 넣지 않아도 된다.
 
 class StickerSerializer(serializers.ModelSerializer):
     class Meta: #paper_id는 views.py에서 입력받으므로 serializer에서는 넣지 않음

--- a/backend/rollpaper/urls.py
+++ b/backend/rollpaper/urls.py
@@ -33,7 +33,7 @@ urlpatterns = [
     path('users/<int:user_id>', views.my_page, name="my_page"), #user_id라는 것이 존재x, User 테이블의 id를 입력받음
     path('papers/<int:user_id>/<paper_id>',views.get_paper), #paper의 memo,image,sticker의 정보를 가져옵니다
     path('papers/sticker_list',views.get_stickers), #스티커 가져오기
-    path('papers/<int:memo_id>/memoxy/', views.memo_xy), # 메모의 x, y좌표 정하기 #주소 끝에 '/'를 넣지 않으면 정상작동하지 않음
+    path('papers/<int:paper_id>/<int:memo_id>/memoxy/', views.memo_xy), # 메모의 x, y좌표 정하기 #주소 끝에 '/'를 넣지 않으면 정상작동하지 않음
 ]
 
 if settings.DEBUG:

--- a/backend/rollpaper/urls.py
+++ b/backend/rollpaper/urls.py
@@ -32,7 +32,8 @@ urlpatterns = [
     path('papers/<int:paper_id>/stickers',views.stickers), #스티커를 추가
     path('users/<int:user_id>', views.my_page, name="my_page"), #user_id라는 것이 존재x, User 테이블의 id를 입력받음
     path('papers/<int:user_id>/<paper_id>',views.get_paper), #paper의 memo,image,sticker의 정보를 가져옵니다
-    path('papers/sticker_list',views.get_stickers)
+    path('papers/sticker_list',views.get_stickers), #스티커 가져오기
+    path('papers/<int:memo_id>/memoxy/', views.memo_xy), # 메모의 x, y좌표 정하기 #주소 끝에 '/'를 넣지 않으면 정상작동하지 않음
 ]
 
 if settings.DEBUG:

--- a/backend/rollpaper/views.py
+++ b/backend/rollpaper/views.py
@@ -138,11 +138,16 @@ def memo_xy(request, paper_id, memo_id):
     memo.save()
 
     #4. 롤링페이퍼에 저장되어있는 메모, 스티커, 이미지 사진 모두 반환
-    memos = Memo.objects.filter(paper=paper_id)
+    memos = Memo.objects.filter(paper=paper_id, is_deleted=1).exclude(xcoor = None, ycoor=None)
     all_memos = list(memos.values())
+    
+    stickers = Sticker.objects.filter(paper=paper_id)
+    all_stickers = list(stickers.values())
 
+    images = Image.objects.filter(paper=paper_id)
+    all_images = list(images.values())
 
-    return JsonResponse({"all_memo": all_memos},status=200)
+    return JsonResponse({"all_memo": all_memos, "all_sticker":all_stickers, "all_images":all_images},status=200)
 
     
 @swagger_auto_schema(method="POST", request_body = MemoDeleteSerializer)
@@ -198,17 +203,17 @@ def my_page(request, user_id):
 def get_paper(request,user_id,paper_id): #user_id는 쓰나?
     #TODO memo 먼저 하자
     dict={"memo":[],"image":[],"sticker":[]}
-    for memo in Memo.objects.filter(paper=paper_id): #아마 리스트 형식으로 쿼리셋을 반환할 거에요
+    for memo in Memo.objects.filter(paper=paper_id, is_deleted=1).exclude(xcoor = None, ycoor=None): #아마 리스트 형식으로 쿼리셋을 반환할 거에요
         json_memo_part = memo_serializer(memo) #memo에서 필요한 정보를 JSON으로 바꿔줍니다
         #근데 JSON으로 바꾸려고 하니까 딕셔너리에 추가할 때 오류가 발생해서 그냥 dic으로 반환
         #memo의 value값에 방금 만든 json을 추가하여 수정해 줍니다
         dict["memo"].append(json_memo_part)
     
-    for image in Image.objects.filter(paper=paper_id):
+    for image in Image.objects.filter(paper=paper_id, is_deleted=1).exclude(xcoor = None, ycoor=None):
         json_image_part = image_serializer(image) #딕셔너리 만들기
         dict["image"].append(json_image_part) #원본에 추가
     
-    for sticker in Sticker.objects.filter(paper_id=paper_id):
+    for sticker in Sticker.objects.filter(paper_id=paper_id).exclude(xcoor = None, ycoor=None):
         json_sticker_part = sticker_serializer(sticker)
         dict["sticker"].append(json_sticker_part)
     

--- a/backend/rollpaper/views.py
+++ b/backend/rollpaper/views.py
@@ -114,23 +114,37 @@ def memo(request,paper_id):
     paper = Paper.objects.get(pk=paper_id)
     font = Font.objects.get(font_type=request.data['font']) #폰트랑 색깔이 삭제되면 메모도 사라져
     color = Color.objects.get(color_type=request.data['color']) #color_id로 저장
+    font_color = Color.objects.get(color_type=request.data['font_color'])
     content = request.data['content']
     nickname = request.data['nickname'] 
-    xcoor = request.data['xcoor']
-    ycoor = request.data['ycoor'] 
-    rotate = request.data['rotate'] 
     password = request.data['password']
     #TODO 1 font랑 Color 테이블에 데이터 만들기(로컬에)
 
     #TODO 2 메모지 만들기
     new_memo = Memo.objects.create(paper=paper, font=font, color=color, content=content,
-    nickname=nickname, xcoor=xcoor, ycoor=ycoor, rotate=rotate, password=password)
+    nickname=nickname, font_color = font_color, password=password)
 
-    return JsonResponse({"message": "memo created"}, status=200)
+    return JsonResponse({"memo_id": new_memo.id}, status=200)
+
+@swagger_auto_schema(method="POST", request_body = MemoXySerializer)
+@api_view(["POST"])
+def memo_xy(request, memo_id):
+    #1. 메모 아이디 가져오기
+    memo = Memo.objects.get(pk=memo_id)
+    #2. 메모의 좌표값 입력받기
+    memo.xcoor = request.data['xcoor']
+    memo.ycoor = request.data['ycoor']
+    #3. 입력받은 좌표값을 DB에 저장
+    memo.save()
+    #4. 모든 메모지의 정보를 불러오기(메모지가 제대로 붙은 롤링페이퍼를 보여주기)
+    
+    #4. 저장되었다는 사실알리기
+    return JsonResponse({"memo's xcoor":memo.xcoor, "memo's ycoor":memo.ycoor},status=200)
+
     
 @swagger_auto_schema(method="POST", request_body = MemoDeleteSerializer)
 @api_view(['POST']) 
-def memo_delete(request,memo_id):
+def memo_delete(request, memo_id):
     #TODO 1: 메모지 가져오기
     memo = Memo.objects.get(pk=memo_id)
         

--- a/backend/rollpaper/views.py
+++ b/backend/rollpaper/views.py
@@ -128,7 +128,7 @@ def memo(request,paper_id):
 
 @swagger_auto_schema(method="POST", request_body = MemoXySerializer)
 @api_view(["POST"])
-def memo_xy(request, memo_id):
+def memo_xy(request, paper_id, memo_id):
     #1. 메모 아이디 가져오기
     memo = Memo.objects.get(pk=memo_id)
     #2. 메모의 좌표값 입력받기
@@ -136,10 +136,13 @@ def memo_xy(request, memo_id):
     memo.ycoor = request.data['ycoor']
     #3. 입력받은 좌표값을 DB에 저장
     memo.save()
-    #4. 모든 메모지의 정보를 불러오기(메모지가 제대로 붙은 롤링페이퍼를 보여주기)
-    
-    #4. 저장되었다는 사실알리기
-    return JsonResponse({"memo's xcoor":memo.xcoor, "memo's ycoor":memo.ycoor},status=200)
+
+    #4. 롤링페이퍼에 저장되어있는 메모, 스티커, 이미지 사진 모두 반환
+    memos = Memo.objects.filter(paper=paper_id)
+    all_memos = list(memos.values())
+
+
+    return JsonResponse({"all_memo": all_memos},status=200)
 
     
 @swagger_auto_schema(method="POST", request_body = MemoDeleteSerializer)
@@ -208,6 +211,8 @@ def get_paper(request,user_id,paper_id): #user_id는 쓰나?
     for sticker in Sticker.objects.filter(paper_id=paper_id):
         json_sticker_part = sticker_serializer(sticker)
         dict["sticker"].append(json_sticker_part)
+    
+    # 메모지의 위치가 지정되지 않아 null인 경우 롤링페이퍼 상에서 출력되지 않도록하기
     
     # json_dict = json.dumps(dict, ensure_ascii=False)
      


### PR DESCRIPTION
## 추가/수정한 기능 설명
메모의 내용과 메모지 색 등을 먼저 설정하여 메모를 생성하고 후에 메모의 좌표를 설정할 수 있게함.
메모의 좌표 설정이 완료되면 좌표 설정이 되어있는 모든 메모의 정보가 반환되도록 함.
삭제된 메모의 정보가 반환되지 않도록 수정함.
<br>


## check list
- [x] issue number를 브랜치 앞에 추가 하였는가?
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
- [x] 추가/수정사항을 설명하였는가?